### PR TITLE
增加一个cookies 连接符号自定义选项

### DIFF
--- a/Task/qqreads.js
+++ b/Task/qqreads.js
@@ -58,6 +58,7 @@ const $ = Env(jsname)
 const notify = $.isNode() ? require('./sendNotify') : '';
 var tz=''
 var kz=''
+var COOKIES_SPLIT='\n'  //自定义多cookie之间连接的分隔符，默认为\n换行分割，不熟悉的不要改动和配置，为了兼容本地node执行
 
 const logs = 0;   //0为关闭日志，1为开启
 const notifyInterval=3
@@ -75,20 +76,24 @@ let qqreadhdArr = [], qqreadheaderVal = '',
     qqreadHD = [], qqreadtimeURL = [], 
     qqreadtimeHD = [];    
   if ($.isNode()) {
-  if (process.env.QQREAD_HEADER && process.env.QQREAD_HEADER.indexOf('\n') > -1) {
-  qqreadHD = process.env.QQREAD_HEADER.split('\n');
+  if (process.env.COOKIES_SPLIT){
+      COOKIES_SPLIT = process.env.COOKIES_SPLIT;
+  };
+  console.log(`============ 分隔符2${COOKIES_SPLIT} =============\n`);
+  if (process.env.QQREAD_HEADER && process.env.QQREAD_HEADER.indexOf(COOKIES_SPLIT) > -1) {
+  qqreadHD = process.env.QQREAD_HEADER.split(COOKIES_SPLIT);
   } else {
       qqreadHD = process.env.QQREAD_HEADER.split()
   };
        
-  if (process.env.QQREAD_TIMEURL && process.env.QQREAD_TIMEURL.indexOf('\n') > -1) {
-  qqreadtimeURL = process.env.QQREAD_TIMEURL.split('\n');
+  if (process.env.QQREAD_TIMEURL && process.env.QQREAD_TIMEURL.indexOf(COOKIES_SPLIT) > -1) {
+  qqreadtimeURL = process.env.QQREAD_TIMEURL.split(COOKIES_SPLIT);
   } else {
       qqreadtimeURL = process.env.QQREAD_TIMEURL.split()
   };
   
-  if (process.env.QQREAD_TIMEHD && process.env.QQREAD_TIMEHD.indexOf('\n') > -1) {
-  qqreadtimeHD = process.env.QQREAD_TIMEHD.split('\n');
+  if (process.env.QQREAD_TIMEHD && process.env.QQREAD_TIMEHD.indexOf(COOKIES_SPLIT) > -1) {
+  qqreadtimeHD = process.env.QQREAD_TIMEHD.split(COOKIES_SPLIT);
   } else {
       qqreadtimeHD = process.env.QQREAD_TIMEHD.split()
   }; 

--- a/Task/qqreads.js
+++ b/Task/qqreads.js
@@ -79,7 +79,7 @@ let qqreadhdArr = [], qqreadheaderVal = '',
   if (process.env.COOKIES_SPLIT){
       COOKIES_SPLIT = process.env.COOKIES_SPLIT;
   };
-  console.log(`============ 分隔符2${COOKIES_SPLIT} =============\n`);
+  console.log(`============ cookies分隔符为：${COOKIES_SPLIT} =============\n`);
   if (process.env.QQREAD_HEADER && process.env.QQREAD_HEADER.indexOf(COOKIES_SPLIT) > -1) {
   qqreadHD = process.env.QQREAD_HEADER.split(COOKIES_SPLIT);
   } else {


### PR DESCRIPTION
本地执行转译获取环境变量`\n`连接符号 转译有问题，增加一个`COOKIES_SPLIT`自定义cookies连接符选项来兼容本地`node`执行，默认值为`\n`不主动配置不影响现有用户